### PR TITLE
show breakdown by queue

### DIFF
--- a/qlook.py
+++ b/qlook.py
@@ -7,7 +7,7 @@ def lines(cmd) :
     return utils.getCommandOutput(cmd)["stdout"].split("\n")
 
 def stats(l) :
-    run  = collections.defaultdict(int)
+    run  = collections.defaultdict(lambda : collections.defaultdict(int))
     wait = collections.defaultdict(int)
 
     for line in l[2:] :
@@ -16,28 +16,33 @@ def stats(l) :
         if "queueName" in vars and not vars["queueName"] in d[vars["queue"]] : continue
         
         if d[vars["state"]]==vars["run"] :
-            run[d[vars["user"]]]+=1
+            run[d[vars["user"]]][d[vars['queue']][:7]]+=1
         else :
             wait[d[vars["user"]]]+=1
     return run,wait
 
 def summary(run, wait) :
-    def printLine(user, r, w) :
+    def printLine(user, rsd, w) :
         on,off = ('\033[91m','\033[0m') if user==os.environ["USER"] else ('','')
-        print "|%s%17s %6d %6d %6d%s|"%(on, user, r, w, r+w, off)
-        
-    print "+--------------------------------------+"
-    print "|      user             r  other  total|"
-    print "|--------------------------------------|"
-    runTotal  = 0
+        rs = [ rsd[queue] for queue in queues ]
+        formRs = '(%s)'%','.join(str(r).rjust(3) for r in rs)
+        print "|%s%17s %s %6d %6d%s|"%(on, user, formRs, w, sum(rs)+w, off)
+
+    queues = sorted(set(sum([user.keys() for user in run.values()],[])))
+
+    print '(%s)'%', '.join(queues)
+    print "+------------------%s---------------+"%(len(queues)*"----")
+    print "|      user        %sr  other  total|"%(len(queues)*"    ")
+    print "|------------------%s---------------|"%(len(queues)*"----")
+    runTotals  = collections.defaultdict(int)
     waitTotal = 0
     for user in sorted(list(set(run.keys()+wait.keys()))) :
-        runTotal += run[user]
+        for q in queues : runTotals[q] += run[user][q]
         waitTotal+=wait[user]
         printLine(user, run[user], wait[user])
-    print "|--------------------------------------|"
-    printLine("all", runTotal, waitTotal)
-    print "+--------------------------------------+"
+    print "|------------------%s---------------|"%(len(queues)*"----")
+    printLine("all", runTotals, waitTotal)
+    print "+------------------%s---------------+"%(len(queues)*"----")
 
 def sample(l) :
     print "\n".join(l)[:-1]


### PR DESCRIPTION
In the case of IC, long, medium, and short are shown separately.  Untested at other sites.  Pull if you like.

```
bbetchar@lx05 ~/work/supy $ ./qlook.py
(heplong, hepmedi, hepshor)
+---------------------------------------------+
|      user                    r  other  total|
|---------------------------------------------|
|         bbetchar (  0,  0, 20)      0     20|
|           futyan (  0,  9,  0)      0      9|
|           jm1103 (  5,  0,175)      7    187|
|---------------------------------------------|
|              all (  5,  9,195)      7    216|
+---------------------------------------------+
```
