### PR TITLE
print the job script which needs needs resubmission 

### DIFF
--- a/__analysisLooper__.py
+++ b/__analysisLooper__.py
@@ -195,7 +195,8 @@ class analysisLooper :
             pickleFileBlocks[-1] = pickleFileBlocks[-1].replace(self.name,self.childName(nSlices,iSlice))
             pickleFileName = '/'.join(pickleFileBlocks)
             if not os.path.exists(pickleFileName) :
-                print "Can't find file : %s"%pickleFileName
+                fields = pickleFileName.split('/')
+                print '/'.join(fields[:-1] + ["job%s.sh"%fields[-1].replace('.pickledData','').split('_')[-1]])
                 foundAll = False
         return foundAll
 


### PR DESCRIPTION
rather than the missing pickledData, for easier resubmission.

Works nicely, except that it is hard to pipe supy output.  I've tried using

supy myanalysis.py | grep job > missing.txt
for x in `cat missing.txt | xargs echo`l do icSub.sh $x; done

The grep is important because it line buffers the output before piping to the file.
Even so, a few lines get parallel-out clobbered
