### PR TITLE
move the tree path from TChain::Add to TChain::TChain

### DIFF
--- a/__analysisLooper__.py
+++ b/__analysisLooper__.py
@@ -103,9 +103,9 @@ class analysisLooper :
         os.system("rm -r %s"%self.tmpDir)
         
     def setupChains(self) :
-        self.chains = dict( [(item,r.TChain("chain%d"%iItem)) for iItem,item in enumerate([self.mainTree]+self.otherTreesToKeepWhenSkimming)])
+        self.chains = dict( [(item,r.TChain("%s/%s"%(item[0], item[1]))) for item in [self.mainTree]+self.otherTreesToKeepWhenSkimming])
         for (dirName,treeName),chain in self.chains.iteritems() :
-            for infile in self.inputFiles : chain.Add("%s/%s/%s"%(infile, dirName, treeName))
+            for infile in self.inputFiles : chain.Add(infile)
             r.SetOwnership(chain, False)
 
         if not self.quietMode :
@@ -221,7 +221,7 @@ class analysisLooper :
         for step,stepDict in filter(lambda s: s[0].isSelector, zip(self.steps, products)) :
             step.increment(True, sum(stepDict["nPass"]))
             step.increment(False,sum(stepDict["nFail"]))
-                
+
         self.printStats()
         print utils.hyphens
         for iStep,step,stepDict in zip(range(len(self.steps)),self.steps,products) :


### PR DESCRIPTION
Hi,

  This should not be an issue reported to supy, but to the people making this kind of files :-(
I have some files on castor that don't contain the '.root' extension (the same happens when the files are on local disk, though).
When supy calls

chain.Add("%s/%s/%s"%(infile, dirName, treeName))(

root tries to open what is in fact 'file+dir+treename', that looks like:
SysError in TRFIOFile::TRFIOFile: file rfio:////castor/cern.ch/grid/atlas/tzero/<long-long-path>/.NTUP_TRIG.x191_m1109._0001.1///trigger can not be opened for reading (Not a directory)

I could get it to work by moving the tree name (+path) from TChain::Add to the TChain costructor.
However, with this solution I had to change the name of the chain (was 'chain0', 'chain1', etc.).
For me it works fine...I don't know whether there was any specific reason for this name.

Thanks,

davide
