### PR TITLE
drop forgotten printout from fileListFromEos

### DIFF
--- a/utils/io.py
+++ b/utils/io.py
@@ -166,7 +166,6 @@ def fileListFromEos(location, itemsToSkip = [], sizeThreshold=0, eos = "", xroot
         if acceptFile :
             fileList.append(xrootdRedirector+location+"/"+fileName)
             sizes.append(size)
-    print fileList
     return fileList
 #####################################
 def fileListFromDisk(location, isDirectory = True, itemsToSkip = [], sizeThreshold = 0) :


### PR DESCRIPTION
I will merge now this one-line change (just dropping a printout from fileListFromEos).
Please forget about the previous 'drop-printout' branch, which included old commits, so I deleted it.

davide
