### PR TITLE
Avoid unnecessary call to TChain::GetEntries()

### DIFF
--- a/__wrappedChain__.py
+++ b/__wrappedChain__.py
@@ -50,7 +50,6 @@ class wrappedChain(dict) :
         """Generate the access dictionary (self) for each entry in TTree."""
         if not self.__chain: return
         chain = self.__chain
-        nEntries = (lambda x,y : min(x,y) if x>=0 else y)( nEntries, chain.GetEntries() ) 
         iTreeFirstEntry = 0
         
         for nTree in range(chain.GetNtrees()) :
@@ -63,7 +62,7 @@ class wrappedChain(dict) :
             for iTreeEntry in range( nTreeEntries )  :
                 if (not nTree) and iTreeEntry==100 : tree.StopCacheLearningPhase()
                 self.entry = iTreeFirstEntry + iTreeEntry
-                if nEntries <= self.entry : self.entry-=1; return
+                if nEntries!=None and nEntries <= self.entry : self.entry-=1; return
                 self.__localEntry = iTreeEntry
                 for node in self.__activeNodeList : node.updated = False
                 yield self


### PR DESCRIPTION
Hi Ted,

This actually results in -1 line of code, and I hope it will rectify the noted abuse of dCache.  There is a major difference running interactively on lx05: looping starts immediately over the ~2400 files in my SingleMu.2011A sample, rather than apparently hanging while opening all the files to get their number of entries.

I don't see any termination logic problems either.  I am running a batch queue test now with nEntries=None, and my success criteria is that jobs finish normally with no crash.

I think it's ok to go ahead and pull this into master.

Burt
