### PR TITLE
Fix example

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -3,7 +3,7 @@ def experiment() :
     return ""
 
 def mainTree() :
-    return ("susyTree/","tree")
+    return ("/","tree")
 
 def otherTreesToKeepWhenSkimming() :
     return []

--- a/examples/configuration.py
+++ b/examples/configuration.py
@@ -1,1 +1,4 @@
 from supy.defaults import *
+
+def mainTree() :
+    return ("susyTree/","tree")


### PR DESCRIPTION
Hi Burt and Ted,

These are minor changes to fix the supy example (a friend of mine started to use supy, so I got a chance to test these again, and see that it was broken).

One comment: I'm not sure whether you want to have 'susyTree' instead of '/' in defaults.py.
If not, we could drop 'examples' and point to https://github.com/davidegerbaudo/supy-minimal-example

davide
