### PR TITLE
Debug nentries

### DIFF
--- a/__wrappedChain__.py
+++ b/__wrappedChain__.py
@@ -50,7 +50,6 @@ class wrappedChain(dict) :
         """Generate the access dictionary (self) for each entry in TTree."""
         if not self.__chain: return
         chain = self.__chain
-        nEntries = (lambda x,y : min(x,y) if x>=0 else y)( nEntries, chain.GetEntries() )
         iTreeFirstEntry = 0
         
         for nTree in range(chain.GetNtrees()) :
@@ -66,8 +65,7 @@ class wrappedChain(dict) :
             for iTreeEntry in range( nTreeEntries )  :
                 if (not nTree) and iTreeEntry==100 : tree.StopCacheLearningPhase()
                 self.entry = iTreeFirstEntry + iTreeEntry
-                if nEntries <= self.entry : self.entry-=1; return
-                #if nEntries!=None and nEntries <= self.entry : self.entry-=1; return
+                if nEntries!=None and -1 < nEntries <= self.entry : self.entry-=1; return
                 self.__localEntry = iTreeEntry
                 for node in self.__activeNodeList : node.updated = False
                 if skip<=self.entry : yield self


### PR DESCRIPTION
Hi Burt and Ted,

  I see that, when I don't specify the number of entries and run in batch, my jobs don't run on any event.
This seems to be due to wrappedChain.entries, for which I see at the first event 

entries(nEntries=-1 ) = -1  
nEntries : -1, self.entry: 0                                                                                                                                                        

so the condition at L68 is satisfied and it exits from the loop.
I believe that this is a bug, and that it can be fixed with the additional "-1<".
Please let me know if this sounds reasonable.

Thanks,

davide

P.S. I don't know why I did not see the problem when the branch below was merged...maybe I tested the branch with a specific n of events...
https://github.com/elaird/supy/pull/112
