### PR TITLE
for reason unknown, the failure happens as expected...

### DIFF
--- a/tests/wrappedchain/__init__.py
+++ b/tests/wrappedchain/__init__.py
@@ -147,6 +147,7 @@ class testEmptyTree(unittest.TestCase):
 
     def test(self):
         runs = []
+        self.assertEqual( 7, self.wc._wrappedChain__chain.GetEntries() )
         for event in self.wc.entries(nEntries=None):
             runs.append(event[self.varName])
         self.assertEqual(runs, range(7))


### PR DESCRIPTION
...if one adds a call to chain.GetEntries() prior to looping.
