### PR TITLE
alternative demonstration

### DIFF
--- a/tests/wrappedchain/__init__.py
+++ b/tests/wrappedchain/__init__.py
@@ -125,6 +125,7 @@ class testEmptyTree(unittest.TestCase):
                      [5,6],
                      [],
                      [],
+                     [7,8],
                      ]
 
         self.writeTFiles()
@@ -147,10 +148,9 @@ class testEmptyTree(unittest.TestCase):
 
     def test(self):
         runs = []
-        self.assertEqual( 7, self.wc._wrappedChain__chain.GetEntries() )
         for event in self.wc.entries(nEntries=None):
             runs.append(event[self.varName])
-        self.assertEqual(runs, range(7))
+        self.assertEqual(runs, range(9))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The tree that gets repeated is the "last one".  The "last one" depends on whether you have called GetEntries().  If you haven't, the "last one" may contain no events itself, in which case no problem of duplicates is observed.  However, if you call GetEntries(), then the chain never sets the address beyond the last valid tree, so that one is the "last one".  If you don't call GetEntries(), you can still get duplicates if there are broken addresses in the chain, and the last address is not broken.
