### PR TITLE
either 1D or 2D, not both; 2D really only needs one of symm|anti

### DIFF
--- a/steps/histos.py
+++ b/steps/histos.py
@@ -99,19 +99,20 @@ class symmAnti(analysisStep) :
         self.other = other
     def uponAcceptance(self,ev) :
         var = ev[self.var]
-        self.book.fill(var, self.var, self.N, self.low, self.up, title = ";%s;events / bin"%self.var)
         if self.other :
             self.book.fill( (var,ev[self.other[0]]), self.var + self.other[0], (self.N,self.other[1]), (self.low,self.other[2]), (self.up,self.other[3]), title = ";%s;%s;events / bin"%(self.var,self.other[0]))
+        else:
+            self.book.fill(var, self.var, self.N, self.low, self.up, title = ";%s;events / bin"%self.var)
+
         symmanti = ev[self.weightVar + "SymmAnti"]
         if not symmanti : return
         sumsymmanti = sum(symmanti)
-        self.book.fill(var, self.var+'_symm', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] *symmanti[0]/sumsymmanti )
-        self.book.fill(var, self.var+'_anti', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] *symmanti[1]/sumsymmanti )
-        self.book.fill(var, self.var+'_flat', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] / sumsymmanti / (self.up-self.low) )
         if self.other :
             self.book.fill( (var, ev[self.other[0]]), self.var+self.other[0]+'_symm', (self.N,self.other[1]), (self.low,self.other[2]), (self.up,self.other[3]), title = ";%s;%s;events / bin"%(self.var,self.other[0]), w = ev['weight'] *symmanti[0]/sumsymmanti )
-            self.book.fill( (var, ev[self.other[0]]), self.var+self.other[0]+'_anti', (self.N,self.other[1]), (self.low,self.other[2]), (self.up,self.other[3]), title = ";%s;%s;events / bin"%(self.var,self.other[0]), w = ev['weight'] *symmanti[1]/sumsymmanti )
-            self.book.fill( (var, ev[self.other[0]]), self.var+self.other[0]+'_flat', (self.N,self.other[1]), (self.low,self.other[2]), (self.up,self.other[3]), title = ";%s;%s;events / bin"%(self.var,self.other[0]), w = ev['weight'] / sumsymmanti / (self.up-self.low) )
+        else:
+            self.book.fill(var, self.var+'_symm', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] *symmanti[0]/sumsymmanti )
+            self.book.fill(var, self.var+'_anti', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] *symmanti[1]/sumsymmanti )
+            self.book.fill(var, self.var+'_flat', self.N, self.low, self.up, title = ";%s;events / bin"%self.var, w = ev['weight'] / sumsymmanti / (self.up-self.low) )
 #####################################
 
 


### PR DESCRIPTION
This is isolated to a step I think no one else is currently using, so I'll merge it right away.
