### PR TITLE
optional predicate step in reweights

### DIFF
--- a/steps/other.py
+++ b/steps/other.py
@@ -153,14 +153,18 @@ class reweights(analysisStep) :
     setup,endFunc,mergeFunc are not, but perhaps it could be
     extended.'''
 
-    def __init__(self,step,reweights,N, doAll=True) :
+    def __init__(self,step,reweights,N, doAll=True, predicate = None) :
         self.moreName="%s(%d); %s;%s"%(reweights,N,step.name,step.moreName)
-        for item in ['step','N','reweights','doAll'] : setattr(self,item,eval(item))
+        if predicate : self.moreName += "; %s;%s"%(predicate.name,predicate.moreName)
+        for item in ['step','N','reweights','doAll','predicate'] : setattr(self,item,eval(item))
         assert not step.isSelector
+        assert not predicate or predicate.isSelector
         self.books = []
 
     def uponAcceptance(self,ev) :
         '''Perform the analysisStep for the default weight, and for each reweight.'''
+
+        if self.predicate and not self.predicate.select(ev) : return
 
         self.step.book = self.book
         self.step.uponAcceptance(ev)


### PR DESCRIPTION
Due to a new requirement of my analysis, I need to plot my signals after two incompatible cuts, so I have added a predicate in this step for convenience.  The theme of predicates could be expanded, for example, I can imagine a more general "steps.other.predicate" step, taking a step to execute along with a "temporary cut" step as a predicate.  We originally designed supy purposefully with linear cut-flow, due to conceptual and coding simplicity, and those reasons may still apply.  Feel free to merge this branch or expand on the theme.
