### PR TITLE
fix batch issue seen on screen session

### DIFF
--- a/__analysisLooper__.py
+++ b/__analysisLooper__.py
@@ -2,6 +2,7 @@ import copy,os,collections
 import configuration
 from supy import autoBook,wrappedChain,utils,keyTracer
 import ROOT as r
+r.gROOT.SetBatch(True)
 #####################################
 class analysisLooper :
     """class to set up and loop over events"""

--- a/__autoBook__.py
+++ b/__autoBook__.py
@@ -1,4 +1,5 @@
 import ROOT as r
+r.gROOT.SetBatch(True)
 
 class autoBook(dict) :
     def __init__(self, arg = None) :

--- a/__organizer__.py
+++ b/__organizer__.py
@@ -1,4 +1,5 @@
 import ROOT as r
+r.gROOT.SetBatch(True)
 import copy,re
 import configuration,utils
 

--- a/__plotter__.py
+++ b/__plotter__.py
@@ -1,4 +1,5 @@
 import ROOT as r
+r.gROOT.SetBatch(True)
 import os,math,string,itertools,re
 import utils,configuration as conf
 from supy import whereami

--- a/__wrappedChain__.py
+++ b/__wrappedChain__.py
@@ -1,5 +1,6 @@
 import copy,array
 import ROOT as r
+r.gROOT.SetBatch(True)
 from collections import defaultdict
 
 class keyTracer(object) :


### PR DESCRIPTION
These lines make sure that root is started in batch mode, no matter
which one is the first module to be pulled in.  Without these lines I
observe (but not with all analyses) the error below:

```
X connection to localhost:32.0 broken (explicit kill or server shutdown).
```

For some reason, which I don't understand, this error seems to show up
only when running supy within a screen session (i.e. it doesn't show
up with the same analysis running within ssh). However, I can
reproduce this error message on lxplus and on other machines (most of
them running SLC5).

An alternative solution, maybe less invasive, would be to make sure that one
module is always imported before the other ones, and have the
`SetBatch(True)` only there.

Please let  me know what you think.

Davide
