### PR TITLE
Fnal cms eos

### DIFF
--- a/utils/io.py
+++ b/utils/io.py
@@ -146,7 +146,7 @@ def fileListFromEos(location, itemsToSkip = [], sizeThreshold=0, eos = "", xroot
     fileList=[]
     sizes=[]
 
-    cmd= eos+" ls -l " +location
+    cmd= eos+" ls -l "+location
     output = getCommandOutput(cmd)
     out = output["stdout"]
     err = output["stderr"]


### PR DESCRIPTION
Hey Ted,

The original idea of adding the eos directory as the value of eosPrefix key didn't quite work since the funcion which lists the files invoked "eos ls -l "+location   and not "eos ls -l "+ eosPrefix + localtion.

In any case, the other simple solution was to replicate what we did for dCache and add a trim.

The changes tested successful, and as far as I can tell the atlas configuration would still work since eosTrim is set to "" as default. 

Y.
