### PR TITLE
Optional slice-level cross-check for nExpected

### DIFF
--- a/__analysis__.py
+++ b/__analysis__.py
@@ -150,12 +150,15 @@ class analysis(object) :
         os.system("rm -r %s"%tmpDir)
 
     def makeInputFileLists(self) :
+        def nEventsFile(fileName):
+            if not configuration.computeEntriesAtMakeFileList(): return None
+            return utils.nEventsFile(fileName,'/'.join(self.mainTree()))
         def makeFileList(name) :
             if os.path.exists(self.inputFilesListFile(name)) and self.useCachedFileLists() : return
             fileNames = eval(self.sampleDict[name].filesCommand)
             assert fileNames, "The command '%s' produced an empty list of files"%self.sampleDict[name].filesCommand
             tmpDir,localFileName,globalFileName = self.globalToLocal(self.inputFilesListFile(name))
-            utils.writePickle(localFileName, fileNames)
+            utils.writePickle(localFileName, zip(fileNames,map(nEventsFile, fileNames)))
             self.localToGlobal(tmpDir, localFileName, globalFileName)
 
         sampleNames = set(sum([[sampleSpec.name for sampleSpec in self.filteredSamples(conf)] for conf in self.configurations],[]))

--- a/defaults.py
+++ b/defaults.py
@@ -37,6 +37,10 @@ def computeEntriesForReport() :
     '''WARNING: If set to True, all files in chain must be read before looping, which may be slow.'''
     return False
 
+def computeEntriesAtMakeFileList():
+    '''WARNING: If set to True, all files in sample must be read before file list is cached, which may be slow.'''
+    return False
+
 def printNodesUsed() :
     '''Dumps nodes accessed from wrappedChain to stdout at end of job: useful for debugging.'''
     return False

--- a/utils/root.py
+++ b/utils/root.py
@@ -120,3 +120,10 @@ def subtractX(hist2D,histX,ratherY=False) :
             divX.SetBinContent(*(args+(divX.GetBinContent(*args)-f,)))
             divX.SetBinError(*(args+(math.sqrt(divX.GetBinError(*args)**2+ferr**2),)))
     return divX
+#####################################
+def nEventsFile(fileName,treeName):
+    tfile = r.TFile.Open(fileName)
+    tree = tfile.Get(treeName)
+    nEntries = tree.GetEntries()
+    tfile.Close()
+    return nEntries


### PR DESCRIPTION
Add a new option (in defaults.py, off by default) to additionally calculate and cache the number of events per file upon creation of file lists, for later use as a cross-check that the output of individual slices contains the expected number of events.  This cross-check requires no hand-entry of expected numbers of events, and causes the failure of just the affected slice, rather than the entire job, in the case that some events go missing.  Can be used in independently of the nCheck argument in sample specification.

This feature is inspired by issue #197, and its implementation has helped to confirm via the FNAL condor stderr messages that missing events occur after a failure to open a file.  It is not clear why such a file-open failure does not cause immediate failure of the supy slice, or if the issue is confined to FNAL.

NB: Cached file lists must be recreated upon adoption of this feature, regardless of whether the feature is enabled.  The new format is of type [(str,int)] or [(str,None)] rather than [str].