### PR TITLE
Site uw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 AutoDict*
 linkdef_cxx.d
 linkdef_cxx.so
+inputFileLists

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -110,11 +110,6 @@ def info(site = prefix(), key = None) :
 def lumiEnvScript() :
     return "sites/%sLumi.sh"%prefix()
 
-def mvCommand(site = None, src = None, dest = None) :
-    d = {#"fnal_cms":"srmcp file:///%s %s/%s"%(src, srmPrefix("fnal"), dest.replace("/pnfs/cms/WAX/","/")),
-        }
-    return "mv %s %s"%(src, dest) if site not in d else d[site]
-
 def srmFunc() :
     return 'utils.fileListFromSrmLs(dCachePrefix = "%s", dCacheTrim = "%s", location="%s'%(info(key = "dCachePrefix"),
                                                                                            info(key = "dCacheTrim"),

--- a/sites/__init__.py
+++ b/sites/__init__.py
@@ -87,9 +87,17 @@ def specs() :
                     "extractCommand" : "tar -xf %s.tar" % os.path.basename(os.environ["PWD"]),
                     "workingDir"     : "${_CONDOR_JOB_IWD}/"+os.path.basename(os.environ["PWD"]),
                     },
-        "uw_cms" :{"localOutputDir" : "/nfs_scratch/%s"%user,
-                   "globalOutputDir": "/nfs_scratch/%s"%user,
-                   },
+        "uw_cms": {"localOutputDir" : os.environ["_CONDOR_SCRATCH_DIR"] if "_CONDOR_SCRATCH_DIR" in os.environ else "/nfs_scratch/%s/supy-tmp/" % user,
+                   "globalOutputDir": "/nfs_scratch/%s/supy-output/" % os.environ["USER"],
+                   "moveOutputFilesBatch": False,
+                   "queueHeaders"   : ["ID", "OWNER", "SUBMITTED1", "SUBMITTED2", "RUN_TIME", "ST", "PRI", "SIZE", "CMD"],
+                   "queueVars"      : {"user":"OWNER", "state":"ST", "run":"R", "userBlackList":["OWNER", "jobs;"],
+                                       "summary":"condor_q -global", "sample": "condor_q -global -submitter %s | head"%user},
+                   "tarCommand"     : "cd ..; tar -chf %s.tar %s/; cd %s" % tuple((os.path.basename(os.environ["PWD"]),)*3),
+                   "extractCommand" : "tar -xf %s.tar" % os.path.basename(os.environ["PWD"]),
+                   "workingDir"     : "${_CONDOR_JOB_IWD}/" + os.path.basename(os.environ["PWD"]),
+                    },
+
         }
 
 def info(site = prefix(), key = None) :

--- a/sites/uw_cmsJob.sh
+++ b/sites/uw_cmsJob.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export SCRAM_ARCH=slc6_amd64_gcc491
+export PATH=${PATH}:/cvmfs/cms.cern.ch/common
+cd /cvmfs/cms.cern.ch/slc6_amd64_gcc491/cms/cmssw/CMSSW_7_4_7/src && eval `scram runtime -sh` && cd - >& /dev/null
+
+#INSERT_BATCH_SETUP

--- a/sites/uw_cmsSub.sh
+++ b/sites/uw_cmsSub.sh
@@ -1,0 +1,1 @@
+condorSub.sh

--- a/sites/uw_cmsTemplate.condor
+++ b/sites/uw_cmsTemplate.condor
@@ -1,0 +1,13 @@
+environment = "USER=USERFLAG"
+Executable = JOBFLAG
+
+transfer_input_files = INFLAG
+transfer_output_files = OUTFLAG
+Should_Transfer_Files = YES
+WhenToTransferOutput = ON_EXIT
+
+Output = JOBFLAG_$(Cluster)_$(Process).stdout
+Error = JOBFLAG_$(Cluster)_$(Process).stderr
+Log = JOBFLAG_$(Cluster)_$(Process).log
+
+Queue


### PR DESCRIPTION
This branch gets supy working at a new site.  It stores the inputFileLists in a subdirectory of supy, in case the globalOutputDir is not readable on worker nodes (as was the case here).  If you have cached file lists that you would like to keep, simply move them to the directory supy/inputFileLists/analysis-name/