### PR TITLE
No divide

### DIFF
--- a/__analysis__.py
+++ b/__analysis__.py
@@ -16,7 +16,7 @@ class analysis(object) :
     def listOfSampleDictionaries(self) : raise Exception("NotImplemented", "Implement a member function %s"%"sampleDict(self)")
     def listOfSamples(self,config) :     raise Exception("NotImplemented", "Implement a member function %s"%"listOfSamples(self,config)")
 
-    def mainTree(self) : return configuration.mainTree()
+    def mainTree(self, *_) : return configuration.mainTree()  # hack to ignore tag by default
     def otherTreesToKeepWhenSkimming(self) : return configuration.otherTreesToKeepWhenSkimming()
     def useCachedFileLists(self) : return configuration.useCachedFileLists()
     def leavesToBlackList(self) : return configuration.leavesToBlackList()
@@ -237,7 +237,7 @@ class analysis(object) :
             assert not nonSteps, "\n\nWarning, the following items from listOfSteps() are not analysisSteps:\n"+('\n'.join(' '+str(s) for s in nonSteps))
             for step in filter(lambda s: s.only not in ['','data' if tup.lumi else 'sim'], adjustedSteps) : step.disabled = True
 
-            return analysisLooper(mainTree=self.mainTree(),
+            return analysisLooper(mainTree=self.mainTree(conf["tag"]),  # hack (see def mainTree() above)
                                   otherTreesToKeepWhenSkimming=self.otherTreesToKeepWhenSkimming(),
                                   nEventsMax=nEventsMax,
                                   leavesToBlackList=self.leavesToBlackList(),

--- a/__analysis__.py
+++ b/__analysis__.py
@@ -139,7 +139,7 @@ class analysis(object) :
         def sampleSpecDict(looper) :
             looper.setupSteps(minimal = True)
             sampleSpec = next( s for s in confSamples if s.weightedName == looper.name ) 
-            return {"name":looper.name, "outputFileName":looper.steps[0].outputFileName,
+            return {"name":looper.name, "outputFileName":looper.steps[0].outputFileName, "nInDivide": sampleSpec.nInDivide,
                     "color":sampleSpec.color, "markerStyle":sampleSpec.markerStyle, "nCheck":self.sampleDict[sampleSpec.name].nCheck }
         return [ sampleSpecDict(looper) for looper in self.listsOfLoopers[tag] ]
 ############

--- a/__analysis__.py
+++ b/__analysis__.py
@@ -16,7 +16,7 @@ class analysis(object) :
     def listOfSampleDictionaries(self) : raise Exception("NotImplemented", "Implement a member function %s"%"sampleDict(self)")
     def listOfSamples(self,config) :     raise Exception("NotImplemented", "Implement a member function %s"%"listOfSamples(self,config)")
 
-    def mainTree(self, *_) : return configuration.mainTree()  # hack to ignore tag by default
+    def mainTree(self) : return configuration.mainTree()
     def otherTreesToKeepWhenSkimming(self) : return configuration.otherTreesToKeepWhenSkimming()
     def useCachedFileLists(self) : return configuration.useCachedFileLists()
     def leavesToBlackList(self) : return configuration.leavesToBlackList()
@@ -237,7 +237,7 @@ class analysis(object) :
             assert not nonSteps, "\n\nWarning, the following items from listOfSteps() are not analysisSteps:\n"+('\n'.join(' '+str(s) for s in nonSteps))
             for step in filter(lambda s: s.only not in ['','data' if tup.lumi else 'sim'], adjustedSteps) : step.disabled = True
 
-            return analysisLooper(mainTree=self.mainTree(conf["tag"]),  # hack (see def mainTree() above)
+            return analysisLooper(mainTree=self.mainTree(),
                                   otherTreesToKeepWhenSkimming=self.otherTreesToKeepWhenSkimming(),
                                   nEventsMax=nEventsMax,
                                   leavesToBlackList=self.leavesToBlackList(),

--- a/__organizer__.py
+++ b/__organizer__.py
@@ -27,8 +27,12 @@ class organizer(object) :
                     [ hist.Scale(  1.0 / sample['nJobs'] ) for hist,sample in zip(self[key],samples) if hist ]
                 elif any([key.startswith(prefix) for prefix in prefixesNoScale]):
                     continue
-                else: [ hist.Scale(sample["xs"]/sample['nEventsIn']) for hist,sample in zip(self[key],samples)
-                        if hist and sample['nEventsIn'] and "xs" in sample ]
+                else:
+                    for hist, sample in zip(self[key], samples):
+                        if hist and "xs" in sample:
+                            hist.Scale(sample["xs"])
+                            if sample['nEventsIn'] and sample["nInDivide"]:
+                                hist.Scale(1.0 / sample['nEventsIn'])
 
         def __str__(self) : return "%s: %s"%self.nameTitle
 

--- a/__plotter__.py
+++ b/__plotter__.py
@@ -37,7 +37,7 @@ def sampleInfo(samples, trim=""):
                 xsEff /= sample["nEventsIn"]
 
             # see docs/mcLumi.txt
-            lumi = sample["nEventsIn"] / xsEff if xsEff else None
+            lumi = sample["nEventsIn"] / xsEff if xsEff else 0.0
         elif "lumi" in sample:
             xsIn = None
             xsEff = None

--- a/__plotter__.py
+++ b/__plotter__.py
@@ -20,16 +20,6 @@ def combineBinContentAndError(histo, binToContainCombo, binToBeKilled) :
     histo.SetBinError(binToContainCombo, math.sqrt(xflowError**2+currentError**2))
 
 
-def mcLumi(nEvents=None, w=None, xs=None, nInDivide=None):
-    """see docs/mcLumi.txt"""
-    if not w*xs:
-        return 0.0
-    if nInDivide:
-        return nEvents**2/(w*xs)
-    else:
-        return nEvents/(w*xs)
-
-
 def sampleName(sample):
     if len(sample.get("sources", [])) == 1:
         return sample["sources"][0]["name"]
@@ -41,17 +31,16 @@ def sampleInfo(samples, trim=""):
     out = []
     for sample in samples:
         if "xs" in sample:
-            if sample["nInDivide"]:
-                xs = sample["xs"]
-            else:
-                xs = sample["xs"] * sample["weightIn"]
-            lumi = mcLumi(nEvents=sample["nEventsIn"],
-                          w=sample["weightIn"],
-                          xs=sample["xs"],
-                          nInDivide=sample["nInDivide"],
-                          )
+            xsIn = sample["xs"]
+            xsEff = sample["xs"] * sample["weightIn"]
+            if sample["nInDivide"] and sample["nEventsIn"]:
+                xsEff /= sample["nEventsIn"]
+
+            # see docs/mcLumi.txt
+            lumi = sample["nEventsIn"] / xsEff if xsEff else None
         elif "lumi" in sample:
-            xs = None
+            xsIn = None
+            xsEff = None
             lumi = sample["lumi"]
         else:
             assert False, sample
@@ -61,10 +50,11 @@ def sampleInfo(samples, trim=""):
             name = name.replace(trim, "")
 
         out.append((name,
-                    "%d" % sample['nEventsIn'],
+                    "%g" % sample['nEventsIn'],  # %g handles 'float epsilon less than nearest int' better than %d
                     "%3.2e" % sample['weightIn'],
                     "%3.2e" % (lumi/1.0e3),
-                    "%3.2e%s" % (xs*1.0e3, " " if sample["nInDivide"] else "*") if xs is not None else "",
+                    "%3.2e" % (xsIn*1.0e3) if xsIn is not None else "",
+                    "%3.2e" % (xsEff*1.0e3) if xsEff is not None else "",
                     ))
     return out
 
@@ -517,7 +507,7 @@ class plotter(object) :
         text.SetTextSize(0.38*text.GetTextSize())
         defSize = text.GetTextSize()
 
-        rows = [("name", "nEventsIn", "weightIn", "lumi(/fb)", "xs(fb)")] + rows
+        rows = [("name", "nEventsIn", "weightIn", "lumi(/fb)", "xsIn(fb)", "xsEff(fb)")] + rows
         realRows = filter(lambda x: len(x[1]), rows)
         if len(realRows) == 1:
             return

--- a/__plotter__.py
+++ b/__plotter__.py
@@ -20,11 +20,14 @@ def combineBinContentAndError(histo, binToContainCombo, binToBeKilled) :
     histo.SetBinError(binToContainCombo, math.sqrt(xflowError**2+currentError**2))
 
 
-def mcLumi(nEvents=None, w=None, xs=None):
+def mcLumi(nEvents=None, w=None, xs=None, nInDivide=None):
     """see docs/mcLumi.txt"""
     if not w*xs:
         return 0.0
-    return nEvents**2/(w*xs)
+    if nInDivide:
+        return nEvents**2/(w*xs)
+    else:
+        return nEvents/(w*xs)
 
 
 def sampleName(sample):
@@ -38,10 +41,15 @@ def sampleInfo(samples, trim=""):
     out = []
     for sample in samples:
         if "xs" in sample:
-            xs = sample["xs"]
+            if sample["nInDivide"]:
+                xs = sample["xs"]
+            else:
+                xs = sample["xs"] * sample["weightIn"]
             lumi = mcLumi(nEvents=sample["nEventsIn"],
                           w=sample["weightIn"],
-                          xs=sample["xs"])
+                          xs=sample["xs"],
+                          nInDivide=sample["nInDivide"],
+                          )
         elif "lumi" in sample:
             xs = None
             lumi = sample["lumi"]
@@ -51,11 +59,12 @@ def sampleInfo(samples, trim=""):
         name = sampleName(sample)
         if trim:
             name = name.replace(trim, "")
+
         out.append((name,
                     "%d" % sample['nEventsIn'],
                     "%3.2e" % sample['weightIn'],
                     "%3.2e" % (lumi/1.0e3),
-                    "%3.2e" % (xs*1.0e3) if xs is not None else "",
+                    "%3.2e%s" % (xs*1.0e3, " " if sample["nInDivide"] else "*") if xs is not None else "",
                     ))
     return out
 

--- a/samples/__init__.py
+++ b/samples/__init__.py
@@ -13,14 +13,14 @@ def printNumberEvents(sampleHolder, treeName='tree'):
 def test(sampleHolder) :
     return [(name,len(eval(ss.filesCommand))) for name,ss in sorted(sampleHolder.items())]
 
-def specify(names = [], overrideLumi = None, xsPostWeights = None, effectiveLumi = None, nFilesMax = None, nEventsMax = None, weights = [], color = 1, markerStyle = 1 , weightedName = None) :
+def specify(names=[], overrideLumi=None, xsPostWeights=None, effectiveLumi=None, nFilesMax=None, nEventsMax=None, weights=[], nInDivide=True, color=1, markerStyle=1 , weightedName=None):
     assert not (overrideLumi and type(names)==list)
     if type(names) != list : names = [names]
     if type(weights) != list : weights = [weights]
-    samplespec = collections.namedtuple("samplespec", "name weightedName overrideLumi xsPostWeights effectiveLumi nFilesMax nEventsMax weights color markerStyle")
+    samplespec = collections.namedtuple("samplespec", "name weightedName overrideLumi xsPostWeights effectiveLumi nFilesMax nEventsMax weights nInDivide color markerStyle")
     weightNames = [w if type(w)==str else w.name for w in weights]
-    return [samplespec(name,'.'.join([name]+weightNames),overrideLumi,xsPostWeights,effectiveLumi,nFilesMax,nEventsMax,weights,color,markerStyle) for name in names]
-    
+    return [samplespec(name, '.'.join([name]+weightNames), overrideLumi, xsPostWeights, effectiveLumi, nFilesMax, nEventsMax, weights, nInDivide, color, markerStyle) for name in names]
+
 class SampleHolder(dict) :
     sample = collections.namedtuple("sample", "filesCommand xs lumi ptHatMin nCheck")
     def __init__(self) : self.inclusiveGroups = []

--- a/samples/__init__.py
+++ b/samples/__init__.py
@@ -17,6 +17,11 @@ def specify(names=[], overrideLumi=None, xsPostWeights=None, effectiveLumi=None,
     assert not (overrideLumi and type(names)==list)
     if type(names) != list : names = [names]
     if type(weights) != list : weights = [weights]
+    if not nInDivide:  # all events are required for correct normalization
+        assert nFilesMax is None
+        assert nEventsMax is None
+        assert effectiveLumi is None
+
     samplespec = collections.namedtuple("samplespec", "name weightedName overrideLumi xsPostWeights effectiveLumi nFilesMax nEventsMax weights nInDivide color markerStyle")
     weightNames = [w if type(w)==str else w.name for w in weights]
     return [samplespec(name, '.'.join([name]+weightNames), overrideLumi, xsPostWeights, effectiveLumi, nFilesMax, nEventsMax, weights, nInDivide, color, markerStyle) for name in names]

--- a/samples/__init__.py
+++ b/samples/__init__.py
@@ -17,10 +17,12 @@ def specify(names=[], overrideLumi=None, xsPostWeights=None, effectiveLumi=None,
     assert not (overrideLumi and type(names)==list)
     if type(names) != list : names = [names]
     if type(weights) != list : weights = [weights]
-    if not nInDivide:  # all events are required for correct normalization
-        assert nFilesMax is None
-        assert nEventsMax is None
-        assert effectiveLumi is None
+
+    if not nInDivide:  # typically, all events are required for correct normalization
+        for s in ["nFilesMax", "nEventsMax", "effectiveLumi"]:
+            x = eval(s)
+            if x is not None:
+                print "WARNING: nInDivide=False, but %s=%s (%s)" % (s, x, str(names))
 
     samplespec = collections.namedtuple("samplespec", "name weightedName overrideLumi xsPostWeights effectiveLumi nFilesMax nEventsMax weights nInDivide color markerStyle")
     weightNames = [w if type(w)==str else w.name for w in weights]

--- a/samples/__init__.py
+++ b/samples/__init__.py
@@ -35,6 +35,7 @@ class SampleHolder(dict) :
         for group in other.inclusiveGroups : self.addInclusiveGroup(group)
 
     def add(self, name, filesCommand = None, xs = None, lumi = None, ptHatMin = None, nCheck = None) :
+        assert "/" not in name,  "name '%s' contains at least one /" % name
         assert name not in self,  "%s already specified" % name
         assert lumi or xs,                      "Underspecified sample: %s"%name
         assert not (lumi and (xs or ptHatMin)), "Overspecified sample: %s"%name

--- a/sites/uw_cmsTemplate.condor
+++ b/sites/uw_cmsTemplate.condor
@@ -6,6 +6,8 @@ transfer_output_files = OUTFLAG
 Should_Transfer_Files = YES
 WhenToTransferOutput = ON_EXIT
 
+Requirements = HAS_CMS_HDFS
+
 Output = JOBFLAG_$(Cluster)_$(Process).stdout
 Error = JOBFLAG_$(Cluster)_$(Process).stderr
 Log = JOBFLAG_$(Cluster)_$(Process).log

--- a/steps/other.py
+++ b/steps/other.py
@@ -46,7 +46,7 @@ class skimmer(analysisStep):
     created.
     """
 
-    def __init__(self, mainChain=True, otherChains=True, extraVars=[], haddOutput=False):
+    def __init__(self, mainChain=True, otherChains=True, extraVars=[], haddOutput=False, suffix="skim"):
         assert mainChain or extraVars
         self.outputTree = None
         self.moreName = "(see below)"
@@ -54,6 +54,7 @@ class skimmer(analysisStep):
             setattr(self, var, eval(var))
         self.addresses = None
         self.haddOutput = haddOutput
+        self.suffix = suffix
 
     def requiresNoSetBranchAddress(self):
         return True  # check
@@ -141,7 +142,7 @@ class skimmer(analysisStep):
         self.outputFile.Close()
 
     def outputSuffix(self):
-        return "_skim.root"
+        return "_%s.root" % self.suffix
 
     def modifiedFileName(self, s):
         l = s.split("/")

--- a/steps/other.py
+++ b/steps/other.py
@@ -50,11 +50,9 @@ class skimmer(analysisStep):
         assert mainChain or extraVars
         self.outputTree = None
         self.moreName = "(see below)"
-        for var in ["mainChain", "otherChains", "extraVars"]:
+        for var in ["mainChain", "otherChains", "extraVars", "haddOutput", "suffix"]:
             setattr(self, var, eval(var))
         self.addresses = None
-        self.haddOutput = haddOutput
-        self.suffix = suffix
 
     def requiresNoSetBranchAddress(self):
         return True  # check


### PR DESCRIPTION
This branch implements an option not to divide MC histograms by the number of events read in.  This is useful when, e.g., the efficiency of a previous skim is not explicitly tracked, but rather a compensating weight is applied event-by-event.  This branch also improves the reporting on the first page of the plotter output and picks up a few unrelated minor improvements.
